### PR TITLE
Update for 1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Below we will walk through instructions for running the pool on minikube in a te
 
 3. Install [minikube](https://minikube.sigs.k8s.io/docs/start/#binary-download)
 
-4. Setup secrets:
+4. Update bcnode image:
+
+    ```bash
+    cd open-overline-pool/docker
+    ./build-images.sh
+    ```
+
+5. Setup secrets:
 
     ```bash
     cd open-overline-pool/k8s
@@ -48,7 +55,7 @@ Below we will walk through instructions for running the pool on minikube in a te
     ./make-secrets.sh
     ```
 
-5. Initialize bcnode (you will need a chainstate snapshot saved as a `.tar.gz` file):
+6. Initialize bcnode (you will need a chainstate snapshot saved as a `.tar.gz` file):
 
     ```bash
     cd open-overline-pool/k8s
@@ -61,20 +68,20 @@ Below we will walk through instructions for running the pool on minikube in a te
     kubectl logs $(kubectl get pods | grep bcnode | awk '{print $1}') -c bcnode -f --tail 10
     ```
 
-6. While the bcnode is syncing, setup redis.
+7. While the bcnode is syncing, setup redis.
 
     ```bash
     kubectl apply -f redis/
     ```
 
-7. Once the bcnode is synced bring open-overline-pool online as follows:
+8. Once the bcnode is synced bring open-overline-pool online as follows:
 
     ```bash
     kubectl apply -f open-overline-pool/
     ./local-port-forward.sh
     ```
 
-8. You should now be able to point a browser to `localhost` and see the splash page. You can also test that the pool is accepting jobs by pointing a overline-compatible stratum miner at it.
+9. You should now be able to point a browser to `localhost` and see the splash page. You can also test that the pool is accepting jobs by pointing a overline-compatible stratum miner at it.
 
 #### Customization
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Below we will walk through instructions for running the pool on minikube in a te
     ```
 
 8. You should now be able to point a browser to `localhost` and see the splash page. You can also test that the pool is accepting jobs by pointing a overline-compatible stratum miner at it.
-9. Edit `k8s/bcnode/deployment.yml` to change the line `- rm -r /data/db;` to `- rm -r /data/db/IDENTITY;` once you have fully synced the node. This change is necessary to allow the node to pick up from where it left off every time instead of loading in from the snapshot as in step 5.
 
 #### Customization
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Below we will walk through instructions for running the pool on minikube in a te
     ```
 
 8. You should now be able to point a browser to `localhost` and see the splash page. You can also test that the pool is accepting jobs by pointing a overline-compatible stratum miner at it.
+9. Edit `k8s/bcnode/deployment.yml` to change the line `- rm -r /data/db;` to `- rm -r /data/db/IDENTITY;` once you have fully synced the node. This change is necessary to allow the node to pick up from where it left off every time instead of loading in from the snapshot as in step 5.
 
 #### Customization
 

--- a/docker/Dockerfile.bcnode
+++ b/docker/Dockerfile.bcnode
@@ -3,20 +3,20 @@ FROM blockcollider/bcnode
 RUN apt-get update && apt-get install -y --no-install-recommends libfile-slurp-perl patch && rm -rf /var/lib/apt/lists/*
 
 # Custom entrypoint
-COPY bcnode/docker-entrypoint.sh /
+#COPY bcnode/docker-entrypoint.sh /
 
-COPY bcnode/monkey-patch /tmp
+#COPY bcnode/monkey-patch /tmp
 
-COPY bcnode/officer.js.patch /tmp
+#COPY bcnode/officer.js.patch /tmp
 
-COPY bcnode/validation.patch /tmp
+#COPY bcnode/validation.patch /tmp
 
-COPY bcnode/multiverse.patch /tmp
+#COPY bcnode/multiverse.patch /tmp
 
-RUN patch ./lib/mining/officer.js /tmp/officer.js.patch
+#RUN patch ./lib/mining/officer.js /tmp/officer.js.patch
 
 # RUN patch ./lib/bc/validation.js /tmp/validation.patch
 
 # RUN patch ./lib/bc/multiverse.js /tmp/multiverse.patch
 
-ENTRYPOINT [ "/docker-entrypoint.sh" ]
+#ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -7,8 +7,8 @@ cp ${POOL_TARBALL_PATH}/${POOL_TARBALL_NAME} ./${POOL_TARBALL_NAME}
 
 docker pull blockcollider/bcnode:latest
 
-#docker build -t local/bcnode -f Dockerfile.bcnode .
-docker build --build-arg POOL_TARBALL_NAME=${POOL_TARBALL_NAME} -t local/open-overline-pool-api -f Dockerfile.api .
+docker build -t local/bcnode -f Dockerfile.bcnode .
+#docker build --build-arg POOL_TARBALL_NAME=${POOL_TARBALL_NAME} -t local/open-overline-pool-api -f Dockerfile.api .
 #docker build --build-arg POOL_TARBALL_NAME=${POOL_TARBALL_NAME} -t local/mining-api-reformatter -f Dockerfile.reformatter .
 #docker build --build-arg POOL_TARBALL_NAME=${POOL_TARBALL_NAME} -t local/open-overline-pool-frontend -f Dockerfile.frontend .
 

--- a/k8s/bcnode/deployment.yml
+++ b/k8s/bcnode/deployment.yml
@@ -88,16 +88,16 @@ spec:
           name: vol-bcnode-db
         command: ['sh','-c']
         args:
-        - rm -r /data/db;
-          if [ ! -d "/data/db" ]; then
+        - if [ ! -d "/data/db" ]; then
             echo "nameserver 8.8.8.8" >> /etc/resolv.conf;
             echo "nameserver 8.8.4.4" >> /etc/resolv.conf;
             apt-get update && apt-get install -y wget unzip;
             until [ -f .uploaded ]; do sleep 1; ls -lh _easysync_db.tar.gz; done;
-            tar -xvzf _easysync_db.tar.gz -C /data --strip-components=1;
+            tar -xvzf _easysync_db.tar.gz -C /data --strip-components=2;
             rm /data/db/IDENTITY;
             rm /data/.chainstate.db;
             rm _easysync_db.tar.gz;
             rm .uploaded;
           fi;
-          echo "done!"
+          echo "done!";
+    # The pod template ends here

--- a/k8s/bcnode/deployment.yml
+++ b/k8s/bcnode/deployment.yml
@@ -88,7 +88,7 @@ spec:
           name: vol-bcnode-db
         command: ['sh','-c']
         args:
-        - rm -r /data/db/IDENTITY;
+        - rm -r /data/db;
           if [ ! -d "/data/db" ]; then
             echo "nameserver 8.8.8.8" >> /etc/resolv.conf;
             echo "nameserver 8.8.4.4" >> /etc/resolv.conf;

--- a/k8s/bcnode/deployment.yml
+++ b/k8s/bcnode/deployment.yml
@@ -21,7 +21,7 @@ spec:
           claimName: pvc-bcnode-db
       containers:
       - name: bcnode
-        image: lgray/bcnode:latest
+        image: blockcollider/bcnode:latest
         volumeMounts:
         - mountPath: /bc/_data
           name: vol-bcnode-db
@@ -44,8 +44,10 @@ spec:
           value: "main"
         - name: MIN_HEALTH_NET
           value: "true"
-        - name: BC_RPC_MINER
+        - name: BC_GRPC_MINER
           value: "true"
+        - name: BC_GRPC_MINER_ADDRESS
+          value: "0.0.0.0:50052"
         - name: BC_MINER_WORKERS
           value: "1"
         - name: NODE_OPTIONS
@@ -86,16 +88,16 @@ spec:
           name: vol-bcnode-db
         command: ['sh','-c']
         args:
-        - if [ ! -d "/data/db" ]; then
+        - rm -r /data/db/IDENTITY;
+          if [ ! -d "/data/db" ]; then
             echo "nameserver 8.8.8.8" >> /etc/resolv.conf;
             echo "nameserver 8.8.4.4" >> /etc/resolv.conf;
             apt-get update && apt-get install -y wget unzip;
             until [ -f .uploaded ]; do sleep 1; ls -lh _easysync_db.tar.gz; done;
-            tar -xvzf _easysync_db.tar.gz -C /data --strip-components=2;
+            tar -xvzf _easysync_db.tar.gz -C /data --strip-components=1;
             rm /data/db/IDENTITY;
             rm /data/.chainstate.db;
             rm _easysync_db.tar.gz;
             rm .uploaded;
           fi;
-          echo "done!";
-    # The pod template ends here
+          echo "done!"


### PR DESCRIPTION
1.2.4 includes ability to natively use bcnode's external miner (https://github.com/trick77/bcnode-gpu-docker/pull/10). Update the images to properly use this.